### PR TITLE
Build KU-DETA static corporate site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# KU-DETA 静的サイト
+
+KU-DETA（岐阜市の肉とチーズのレストラン）のコーポレートサイトを、単一ページ構成（`index.html`、`styles.css`、`main.js`）で実装しています。モバイルファーストのレスポンシブデザインで、メニュータブ、予約フォーム、採用応募フォーム、Instagram埋め込み、構造化データなどを備えています。
+
+## 編集ポイント
+
+ページ上部の `<body>` 要素に設定している `data-*` 属性を更新すると、住所・営業時間・電話番号・予約URL・Instagramハンドル・席数などがページ全体で自動的に反映されます。
+
+```html
+<body
+  data-address="岐阜県岐阜市〇〇町1-2-3"
+  data-hours="ランチ 11:30-15:00 (L.O.14:00) / ディナー 17:30-23:00 (L.O.22:00)"
+  data-phone="058-000-0000"
+  data-reservation-url="https://example.com/reserve"
+  data-instagram="@ku_deta_gifu"
+  data-seats="テーブル40席 / カウンター6席"
+>
+```
+
+必要に応じて以下も編集してください。
+
+- **メニューや価格の変更**：`index.html` 内の該当セクションを更新します。JSON-LD（構造化データ）は `main.js` 内の `ldMenu` オブジェクトを編集してください。
+- **フォームの送信先**：現在はフロントエンド側でのバリデーション後に完了メッセージを表示するダミー動作です。実運用に合わせて `main.js` の `reserveForm` / `recruitForm` ハンドラをサーバー送信に置き換えてください。
+- **Instagram**：埋め込み先の投稿URLを更新する場合は `#instagram` セクションの `data-instgrm-permalink` を差し替えてください。
+
+## ビルド / 起動方法
+
+静的ファイルのみの構成です。以下の手順でローカルプレビューが可能です。
+
+```bash
+# 任意のHTTPサーバーで配信します（例：python）
+python -m http.server 3000
+# ブラウザで http://localhost:3000/index.html を開く
+```
+
+CDN や任意の静的ホスティングサービスに `index.html`、`styles.css`、`main.js` をアップロードするだけで稼働します。

--- a/index.html
+++ b/index.html
@@ -1,1 +1,580 @@
+<!DOCTYPE html>
+<html lang="ja" data-seo-title="KU-DETA | 肉とチーズで心も体も元気に" data-seo-description="岐阜市・KU-DETAの公式サイト。NY/LA/Chicago/Austinの4都市エッセンスが息づく活気あるオープンキッチンで、肉とチーズを全身で味わう時間を。ランチ・ディナー・コース・飲み放題・記念日プレートのご案内。">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>KU-DETA | 肉とチーズで心も体も元気に</title>
+  <meta name="description" content="岐阜市・KU-DETAの公式サイト。NY/LA/Chicago/Austinの4都市エッセンスが息づく活気あるオープンキッチンで、肉とチーズを全身で味わう時間を。ランチ・ディナー・コース・飲み放題・記念日プレートのご案内。" />
+  <meta property="og:title" content="KU-DETA | 肉とチーズで心も体も元気に" />
+  <meta property="og:description" content="ニューヨーク・ロサンゼルス・シカゴ・オースティンのエネルギーを閉じ込めた岐阜市の肉とチーズレストランKU-DETA。ランチ・ディナー・コースの予約受付中。" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://example.com/" />
+  <meta property="og:image" content="https://images.unsplash.com/photo-1604908177093-3fb91f091c50?auto=format&fit=crop&w=1200&q=80" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="canonical" href="https://example.com/" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body data-address="岐阜県岐阜市〇〇町1-2-3" data-hours="ランチ 11:30-15:00 (L.O.14:00) / ディナー 17:30-23:00 (L.O.22:00)" data-phone="058-000-0000" data-reservation-url="https://example.com/reserve" data-instagram="@ku_deta_gifu" data-seats="テーブル40席 / カウンター6席">
+  <a class="visually-hidden" href="#main">メインコンテンツへ移動</a>
+  <header data-shrink="false">
+    <div class="header-inner">
+      <div class="brand" aria-label="KU-DETA">
+        <span>KU-DETA</span>
+      </div>
+      <button class="nav-toggle" type="button" aria-label="ナビゲーションを開閉" aria-expanded="false">☰</button>
+      <nav aria-label="主要ナビゲーション" aria-expanded="false">
+        <a href="#concept">コンセプト</a>
+        <a href="#menu">メニュー</a>
+        <a href="#course">コース</a>
+        <a href="#wine">ワイン</a>
+        <a href="#space">空間</a>
+        <a href="#access">アクセス</a>
+        <a href="#reserve">予約</a>
+      </nav>
+      <a class="reserve-button" data-reserve-link href="#reserve">席を予約する</a>
+    </div>
+  </header>
 
+  <main id="main">
+    <section class="hero" id="hero" aria-labelledby="hero-heading">
+      <div class="hero-content">
+        <h1 id="hero-heading">肉とチーズで、心も体も元気に。</h1>
+        <p>アメリカ4都市を巡るような、活気あふれるオープンキッチン。</p>
+        <div class="hero-actions">
+          <a class="primary" data-reserve-link href="#reserve">席を予約する</a>
+          <a class="secondary" href="#course">コースを見る</a>
+          <a class="secondary" data-phone-link href="tel:0580000000">電話で相談</a>
+        </div>
+        <div class="badges" aria-label="店舗情報">
+          <span class="badge">Open Kitchen</span>
+          <span class="badge">Meat &amp; Cheese</span>
+          <span class="badge">NY / LA / Chicago / Austin</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="concept" aria-labelledby="concept-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 class="section-title" id="concept-heading">コンセプト</h2>
+          <p class="section-subtitle">KU-DETAは、肉とチーズを主役に“心も体も元気にする”時間をお届けします。ニューヨークの洗練、ロサンゼルスの軽やかさ、シカゴの力強さ、オースティンのスパイス——4つの街のエッセンスを空間と料理に。40席のテーブル、6席のカウンター、オープンキッチンのライブ感をどうぞ。</p>
+        </div>
+        <div class="city-grid">
+          <article class="city-card">
+            <h3>New York</h3>
+            <p><span class="tag">洗練</span>ネオンが灯るナイトライフをイメージしたカクテルカウンター。</p>
+          </article>
+          <article class="city-card">
+            <h3>Los Angeles</h3>
+            <p><span class="tag">ヘルシー</span>旬野菜と発酵を取り入れたパワーサラダ＆チーズフォンデュ。</p>
+          </article>
+          <article class="city-card">
+            <h3>Chicago</h3>
+            <p><span class="tag">ディープ</span>肉厚なシカゴピザとスモーク香るグリルゾーン。</p>
+          </article>
+          <article class="city-card">
+            <h3>Austin</h3>
+            <p><span class="tag">BBQ</span>スパイスが効いたファヒータとライブ感満点のグリル台。</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="menu" aria-labelledby="menu-heading">
+      <div class="container menu-tabs">
+        <div class="section-header">
+          <h2 class="section-title" id="menu-heading">ランチ &amp; ディナー</h2>
+          <p class="section-subtitle">昼から全力チャージ。夜はアメリカン×イタリアンの良いとこ取り。</p>
+        </div>
+        <div class="menu-tablist" role="tablist" aria-label="メニュータブ">
+          <button role="tab" aria-selected="true" aria-controls="lunch-panel" id="tab-lunch">ランチ</button>
+          <button role="tab" aria-selected="false" aria-controls="dinner-panel" id="tab-dinner" tabindex="-1">ディナー</button>
+          <button role="tab" aria-selected="false" aria-controls="dessert-panel" id="tab-dessert" tabindex="-1">デザート</button>
+        </div>
+        <div id="lunch-panel" class="menu-panel" role="tabpanel" aria-labelledby="tab-lunch" aria-hidden="false">
+          <article class="menu-item">
+            <div class="details">
+              <strong>牛カツランチ <span class="highlight-tag">人気</span></strong>
+              <p>肉厚な牛カツと自家製ハムのパワーサラダ。ライス付きで満足度◎。</p>
+            </div>
+            <span class="price">¥1,600</span>
+          </article>
+          <article class="menu-item">
+            <div class="details">
+              <strong>チーズフォンデュランチ <span class="highlight-tag">限定</span></strong>
+              <p>4種チーズの濃厚フォンデュをアメリカ西海岸スタイルで。</p>
+            </div>
+            <span class="price">¥1,800</span>
+          </article>
+          <article class="menu-item">
+            <div class="details">
+              <strong>ハンバーグプレート <span class="highlight-tag">定番</span></strong>
+              <p>鉄板で焼き上げるジューシーなハンバーグ。ライス＆サラダ付き。</p>
+            </div>
+            <span class="price">¥1,500</span>
+          </article>
+        </div>
+        <div id="dinner-panel" class="menu-panel" role="tabpanel" aria-labelledby="tab-dinner" aria-hidden="true">
+          <article class="menu-item">
+            <div class="details">
+              <strong>ワカモレ &amp; トルティーヤ <span class="highlight-tag">人気</span></strong>
+              <p>オースティンを感じるスモーキーなチリライムワカモレ。</p>
+            </div>
+            <span class="price">¥900</span>
+          </article>
+          <article class="menu-item">
+            <div class="details">
+              <strong>ファヒータ鉄板 <span class="highlight-tag">ライブ感</span></strong>
+              <p>オープンキッチンで仕上げるシズルたっぷりのファヒータ。</p>
+            </div>
+            <span class="price">¥1,600</span>
+          </article>
+          <article class="menu-item">
+            <div class="details">
+              <strong>シカゴピザ <span class="highlight-tag">厚焼</span></strong>
+              <p>肉とチーズを層に重ねたディープディッシュ。焼き立てをテーブルへ。</p>
+            </div>
+            <span class="price">¥1,800</span>
+          </article>
+          <article class="menu-item">
+            <div class="details">
+              <strong>USリブアイステーキ</strong>
+              <p>NYのステーキハウスを思わせる分厚いカット。特製バターで。</p>
+            </div>
+            <span class="price">¥2,800</span>
+          </article>
+        </div>
+        <div id="dessert-panel" class="menu-panel" role="tabpanel" aria-labelledby="tab-dessert" aria-hidden="true">
+          <article class="menu-item">
+            <div class="details">
+              <strong>自家製バスクチーズケーキ <span class="highlight-tag">定番</span></strong>
+              <p>表面は香ばしく、中はとろり。赤ワインとのペアリングも◎。</p>
+            </div>
+            <span class="price">¥620</span>
+          </article>
+          <article class="menu-item">
+            <div class="details">
+              <strong>カタラーナ</strong>
+              <p>濃厚なチーズクリームを凍らせ、仕上げにキャラメリゼ。</p>
+            </div>
+            <span class="price">¥600</span>
+          </article>
+          <article class="menu-item">
+            <div class="details">
+              <strong>プリン</strong>
+              <p>どこか懐かしいリッチプリン。ほろ苦カラメルがアクセント。</p>
+            </div>
+            <span class="price">¥500</span>
+          </article>
+          <article class="menu-item">
+            <div class="details">
+              <strong>今月の限定チーズケーキ <span class="highlight-tag">今月の限定</span></strong>
+              <p>季節のチーズとフルーツをかけ合わせたスペシャルスイーツ。</p>
+            </div>
+            <span class="price">¥700</span>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="course" aria-labelledby="course-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 class="section-title" id="course-heading">コース &amp; 飲み放題</h2>
+          <p class="section-subtitle">シーンに合わせて選べる3コース。飲み放題はアルコール¥2,000／ノンアル¥1,500。</p>
+        </div>
+        <div class="course-comparison">
+          <table class="course-table" aria-describedby="course-heading">
+            <thead>
+              <tr>
+                <th scope="col">コース名</th>
+                <th scope="col">価格</th>
+                <th scope="col">内容</th>
+                <th scope="col">おすすめシーン</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Standard</th>
+                <td>¥4,000</td>
+                <td>前菜盛合せ／パワーサラダ／メイン（肉 or 魚）／デザート</td>
+                <td>初めてのご来店やカジュアルなお集まりに。</td>
+              </tr>
+              <tr>
+                <th scope="row">Signature</th>
+                <td>¥5,000</td>
+                <td>ライブキッチン前菜／シカゴピザ／USステーキ／バスクチーズケーキ</td>
+                <td>記念日や大切なディナーに。メッセージプレート対応可。</td>
+              </tr>
+              <tr>
+                <th scope="row">Chef's Choice</th>
+                <td>¥6,000</td>
+                <td>シェフおまかせタパス／リブアイ＆ファヒータ／限定チーズケーキ</td>
+                <td>接待やパーティーで料理をしっかり楽しみたい方へ。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="card-grid two" style="margin-top:2rem;">
+          <article class="card">
+            <h3>飲み放題</h3>
+            <ul>
+              <li>アルコール ¥2,000（クラフトビール・ワイン・ハイボール）</li>
+              <li>ノンアル ¥1,500（自家製レモネード・ティーソーダなど）</li>
+              <li>90分制／ラストオーダーは15分前</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>メッセージプレート</h3>
+            <p>お祝いプレート ¥550（デザート＋お祝いメッセージ）。記念日や送別会に。</p>
+            <a class="reserve-button" data-reserve-link href="#reserve" style="justify-self:flex-start;">記念日相談</a>
+          </article>
+        </div>
+        <div class="faq-list" style="margin-top:2.5rem;">
+          <div class="faq-item">
+            <h3>予約はいつまでに必要？</h3>
+            <p>週末は特に混み合います。オンライン予約フォームまたはお電話にてお早めにご連絡ください。</p>
+          </div>
+          <div class="faq-item">
+            <h3>人数変更は可能？</h3>
+            <p>前日までにお電話いただければ柔軟に調整いたします。当日キャンセルはコース料金を頂戴する場合がございます。</p>
+          </div>
+          <div class="faq-item">
+            <h3>アレルギー対応は？</h3>
+            <p>可能な限り対応いたします。ご予約時に詳細をお知らせください。</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="specialty" aria-labelledby="specialty-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 class="section-title" id="specialty-heading">スペシャリテ &amp; デザート</h2>
+          <p class="section-subtitle">肉とチーズのシグネチャーに、毎月限定のチーズケーキまで。</p>
+        </div>
+        <div class="card-grid three">
+          <article class="card">
+            <h3>NYカット ステーキ</h3>
+            <p>シグネチャーのUSリブアイを高温で焼き上げ、仕上げに骨髄バターを添えます。</p>
+          </article>
+          <article class="card">
+            <h3>LAグリーン パワーサラダ</h3>
+            <p>自家製ハムと発酵ドレッシング、季節のフルーツをのせた彩りサラダ。</p>
+          </article>
+          <article class="card">
+            <h3>今月の限定チーズケーキ</h3>
+            <p>旬の食材を合わせたスペシャルチーズケーキ。Instagramで今月のフレーバーを発信中。</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="wine" aria-labelledby="wine-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 class="section-title" id="wine-heading">ワイン &amp; ペアリング</h2>
+          <p class="section-subtitle">アメリカワイン中心。肉とチーズに寄り添う一本をソムリエがご提案。</p>
+        </div>
+        <div class="wine-grid">
+          <article class="wine-card">
+            <h3>グラスワイン</h3>
+            <p>カリフォルニアのシャルドネやオレゴンのピノ・ノワールを日替わりで。</p>
+            <p>牛カツにはナパのカベルネ、チーズフォンデュにはソノマのシャルドネを。</p>
+          </article>
+          <article class="wine-card">
+            <h3>ボトルセレクション</h3>
+            <p>テキサス・ハイプレーンズのジンファンデルやNYフィンガーレイクスのリースリングなど多彩に。</p>
+            <p>NYカットステーキにはカリフォルニアのボルドーブレンドを。</p>
+          </article>
+          <article class="wine-card">
+            <h3>ノンアルコール</h3>
+            <p>自家製クラフトコーラやビーツレモネードで乾杯。お子様やドライバーにも。</p>
+            <p>ファヒータにはチリライムスパーク、デザートにはハニーアールグレイティーを。</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="space" aria-labelledby="space-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 class="section-title" id="space-heading">空間紹介</h2>
+          <p class="section-subtitle">オープンキッチンと4都市の世界観が交錯する活気あるフロア。<span data-bind="seats"></span></p>
+        </div>
+        <div class="card-grid two">
+          <article class="card">
+            <h3>オープンキッチン</h3>
+            <p>ライブで焼き上がるステーキやファヒータを目の前で楽しめるレイアウト。</p>
+          </article>
+          <article class="card">
+            <h3>ゾーニング</h3>
+            <p>NYラウンジ・LAテラス・シカゴピザベイ・オースティングリルの4ゾーンを回遊。</p>
+          </article>
+        </div>
+        <div class="gallery" aria-label="店内ギャラリー">
+          <img src="https://images.unsplash.com/photo-1540189549336-e6e99c3679fe?auto=format&fit=crop&w=800&q=80" alt="店内のオープンキッチンの様子" loading="lazy" />
+          <img src="https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=800&q=80" alt="テーブル席" loading="lazy" />
+          <img src="https://images.unsplash.com/photo-1481833761820-0509d3217039?auto=format&fit=crop&w=800&q=80" alt="カウンター席" loading="lazy" />
+          <img src="https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=800&q=80" alt="ステーキの盛り付け" loading="lazy" />
+          <img src="https://images.unsplash.com/photo-1527169402691-feff5539e52c?auto=format&fit=crop&w=800&q=80" alt="チーズ料理" loading="lazy" />
+          <img src="https://images.unsplash.com/photo-1499028344343-cd173ffc68a9?auto=format&fit=crop&w=800&q=80" alt="デザート" loading="lazy" />
+        </div>
+        <div class="testimonials" style="margin-top:2rem;">
+          <article class="testimonial">「ライブ感あふれるカウンターでステーキを楽しめるのが最高。記念日プレートも喜んでもらえました。」</article>
+          <article class="testimonial">「ランチの牛カツはサラダもハムもボリュームたっぷり。午後から頑張れるエネルギー補給です。」</article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="gallery" aria-labelledby="gallery-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 class="section-title" id="gallery-heading">フォトギャラリー</h2>
+          <p class="section-subtitle">撮りたくなる瞬間が連続する、KU-DETAのとっておき。</p>
+        </div>
+        <div class="gallery" aria-label="料理と空間の写真">
+          <img src="https://images.unsplash.com/photo-1547592166-23ac45744acd?auto=format&fit=crop&w=800&q=80" alt="シェアする料理" loading="lazy" />
+          <img src="https://images.unsplash.com/photo-1543353071-873f17a7a088?auto=format&fit=crop&w=800&q=80" alt="ワインボトル" loading="lazy" />
+          <img src="https://images.unsplash.com/photo-1528834352189-46be05f11536?auto=format&fit=crop&w=800&q=80" alt="カクテル" loading="lazy" />
+          <img src="https://images.unsplash.com/photo-1470337458703-46ad1756a187?auto=format&fit=crop&w=800&q=80" alt="チーズプレート" loading="lazy" />
+          <img src="https://images.unsplash.com/photo-1499636136210-6f4ee915583e?auto=format&fit=crop&w=800&q=80" alt="ピザ" loading="lazy" />
+          <img src="https://images.unsplash.com/photo-1496417263034-38ec4f0b665a?auto=format&fit=crop&w=800&q=80" alt="ディナータイム" loading="lazy" />
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="access" aria-labelledby="access-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 class="section-title" id="access-heading">アクセス</h2>
+          <p class="section-subtitle">最寄り駅から徒歩5分。専用駐車場あり。</p>
+        </div>
+        <div class="access-grid">
+          <div>
+            <h3>店舗情報</h3>
+            <p><strong>住所：</strong><span data-bind="address"></span></p>
+            <p><strong>営業時間：</strong><span data-bind="hours"></span></p>
+            <p><strong>電話：</strong><a data-bind="phone" data-phone-link href="tel:0580000000">058-000-0000</a></p>
+            <p><strong>席数：</strong><span data-bind="seats"></span></p>
+            <p><strong>Instagram：</strong><a data-instagram-link data-bind="instagram" href="https://www.instagram.com/ku_deta_gifu/" target="_blank" rel="noopener">@ku_deta_gifu</a></p>
+            <div class="card" style="margin-top:1.5rem;">
+              <h3>アクセスメモ</h3>
+              <ul>
+                <li>名鉄岐阜駅 徒歩5分</li>
+                <li>提携駐車場あり（2時間無料）</li>
+                <li>ベビーカー・車椅子OK</li>
+              </ul>
+            </div>
+          </div>
+          <div class="map-embed" aria-label="Googleマップ">
+            <iframe title="KU-DETA所在地" loading="lazy" allowfullscreen src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3269.800887253518!2d136.7606340764449!3d35.40957807265267!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x6003a95ec9fe1f7d%3A0xb35a1b5db665d77c!2z5bKp5biD5aSn5a2m!5e0!3m2!1sja!2sjp!4v1700000000000" referrerpolicy="no-referrer-when-downgrade"></iframe>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="reserve" aria-labelledby="reserve-heading">
+      <div class="container">
+        <div class="reserve-card">
+          <div>
+            <h2 class="section-title" id="reserve-heading">予約・お問い合わせ</h2>
+            <p>オンラインフォームまたはお電話で承ります。貸切や記念日のご相談もお気軽に。</p>
+            <div class="form-actions" style="padding:0;">
+              <a class="reserve-button" data-phone-link href="tel:0580000000">電話で相談</a>
+              <a class="reserve-button" data-reserve-link href="https://example.com/reserve">外部予約サイト</a>
+            </div>
+          </div>
+          <form id="reserve-form" novalidate aria-describedby="reserve-feedback">
+            <label>
+              <span>お名前 *</span>
+              <input type="text" name="name" autocomplete="name" required />
+              <span class="error-message" aria-live="polite"></span>
+            </label>
+            <label>
+              <span>メールアドレス *</span>
+              <input type="email" name="email" autocomplete="email" required />
+              <span class="error-message" data-error="email" aria-live="polite"></span>
+            </label>
+            <label>
+              <span>電話番号 *</span>
+              <input type="tel" name="phone" autocomplete="tel" required />
+              <span class="error-message" data-error="phone" aria-live="polite"></span>
+            </label>
+            <label>
+              <span>ご来店日 *</span>
+              <input type="date" name="date" required />
+              <span class="error-message" aria-live="polite"></span>
+            </label>
+            <label>
+              <span>ご来店時間 *</span>
+              <input type="time" name="time" required />
+              <span class="error-message" aria-live="polite"></span>
+            </label>
+            <label>
+              <span>人数 *</span>
+              <select name="guests" required>
+                <option value="">選択してください</option>
+                <option value="2">2名</option>
+                <option value="3">3名</option>
+                <option value="4">4名</option>
+                <option value="5">5名</option>
+                <option value="6">6名以上</option>
+              </select>
+              <span class="error-message" aria-live="polite"></span>
+            </label>
+            <label>
+              <span>ご要望</span>
+              <textarea name="requests" rows="3" placeholder="アレルギーや記念日メッセージなど"></textarea>
+              <span class="error-message" aria-live="polite"></span>
+            </label>
+            <div class="notice">reCAPTCHA v3でスパム対策予定／送信で仮予約となります。</div>
+            <div class="form-actions">
+              <button type="submit">送信する</button>
+              <small>送信後、担当者より確認のお電話をいたします。</small>
+            </div>
+            <div id="reserve-feedback" aria-live="polite"></div>
+          </form>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="instagram" aria-labelledby="instagram-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 class="section-title" id="instagram-heading">Instagram</h2>
+          <p class="section-subtitle">@ku_deta_gifu の最新シーン。来店前にムードをチェック。</p>
+        </div>
+        <div class="instagram-grid">
+          <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/Cw0pTzMy0wT/" data-instgrm-version="14" style="background:#fff;padding:0;" loading="lazy"></blockquote>
+          <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CxWES5zy5zX/" data-instgrm-version="14" style="background:#fff;padding:0;" loading="lazy"></blockquote>
+          <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/Cv2Xh5fSP1U/" data-instgrm-version="14" style="background:#fff;padding:0;" loading="lazy"></blockquote>
+          <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CuIxwNfSOR8/" data-instgrm-version="14" style="background:#fff;padding:0;" loading="lazy"></blockquote>
+          <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CtFd8YPSl2b/" data-instgrm-version="14" style="background:#fff;padding:0;" loading="lazy"></blockquote>
+          <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CshzHWcyXUo/" data-instgrm-version="14" style="background:#fff;padding:0;" loading="lazy"></blockquote>
+        </div>
+        <script async src="https://www.instagram.com/embed.js"></script>
+      </div>
+    </section>
+
+    <section class="section" id="recruit" aria-labelledby="recruit-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 class="section-title" id="recruit-heading">採用情報</h2>
+          <p class="section-subtitle">「接客・空間・雰囲気」も私たちの商品。一緒に、心も体も元気にするお店をつくりませんか？</p>
+        </div>
+        <div class="card-grid two">
+          <article class="card">
+            <h3>求めるマインド</h3>
+            <ul>
+              <li>お客様の笑顔と体験価値を第一に考えられる</li>
+              <li>チームで連携し、活気ある現場を楽しめる</li>
+              <li>料理・接客・空間づくりすべてに好奇心を持てる</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h3>評価制度（100点満点）</h3>
+            <ol>
+              <li>ホスピタリティ（20点）</li>
+              <li>商品理解（15点）</li>
+              <li>チーム連携（15点）</li>
+              <li>スピード＆正確性（15点）</li>
+              <li>クリエイティビティ（15点）</li>
+              <li>セルフケア＆成長意欲（20点）</li>
+            </ol>
+          </article>
+        </div>
+        <div class="card" style="margin-top:2rem;">
+          <h3>応募フォーム</h3>
+          <form id="recruit-form" novalidate>
+            <label>
+              <span>氏名 *</span>
+              <input type="text" name="applicant" required />
+              <span class="error-message" aria-live="polite"></span>
+            </label>
+            <label>
+              <span>連絡先（メールまたは電話） *</span>
+              <input type="text" name="contact" required />
+              <span class="error-message" aria-live="polite"></span>
+            </label>
+            <label>
+              <span>希望職種 *</span>
+              <select name="position" required>
+                <option value="">選択してください</option>
+                <option value="kitchen">キッチン</option>
+                <option value="service">ホール・バーテンダー</option>
+                <option value="manager">マネジメント</option>
+                <option value="part-time">アルバイト</option>
+              </select>
+              <span class="error-message" aria-live="polite"></span>
+            </label>
+            <label>
+              <span>勤務可能時間 *</span>
+              <input type="text" name="availability" placeholder="例：平日18:00以降、土日終日" required />
+              <span class="error-message" aria-live="polite"></span>
+            </label>
+            <label>
+              <span>自由記述</span>
+              <textarea name="message" rows="3" placeholder="志望動機やスキルなど"></textarea>
+              <span class="error-message" aria-live="polite"></span>
+            </label>
+            <label>
+              <span>履歴書（PDF） *</span>
+              <input type="file" name="resume" accept="application/pdf" required />
+              <span class="error-message" aria-live="polite" data-error="resume"></span>
+            </label>
+            <div class="form-actions">
+              <button type="submit">応募する</button>
+              <small>送信後3営業日以内にご連絡いたします。</small>
+            </div>
+            <div id="recruit-feedback" aria-live="polite"></div>
+          </form>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-top">
+      <div class="footer-brand">
+        <h2>KU-DETA</h2>
+        <p>肉とチーズ、そして空間とサービスで「心も体も元気に」を届けます。</p>
+      </div>
+      <div class="footer-nav">
+        <a href="#menu">メニュー</a>
+        <a href="#course">コース</a>
+        <a href="#wine">ワイン</a>
+        <a href="#reserve">予約</a>
+        <a href="#recruit">採用情報</a>
+      </div>
+      <div class="footer-cta">
+        <strong>すぐに予約する</strong>
+        <a class="reserve-button" data-reserve-link href="#reserve">オンライン予約</a>
+        <a data-phone-link href="tel:0580000000">電話：<span data-bind="phone"></span></a>
+        <a data-instagram-link href="https://www.instagram.com/ku_deta_gifu/" target="_blank" rel="noopener">Instagramで最新情報</a>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <div>
+        <p>住所：<span data-bind="address"></span></p>
+        <p>営業時間：<span data-bind="hours"></span></p>
+      </div>
+      <div>
+        <p>&copy; <span id="current-year"></span> KU-DETA. All Rights Reserved.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script defer src="main.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const year = new Date().getFullYear();
+      const yearEl = document.getElementById('current-year');
+      if (yearEl) {
+        yearEl.textContent = year;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,298 @@
+(function () {
+  const body = document.body;
+  const dataset = body.dataset;
+  const info = {
+    address: dataset.address || '岐阜県岐阜市〇〇町1-2-3',
+    hours: dataset.hours || 'ランチ 11:30-15:00 (L.O.14:00) / ディナー 17:30-23:00 (L.O.22:00)',
+    phone: dataset.phone || '000-000-0000',
+    reservationUrl: dataset.reservationUrl || '#reserve',
+    instagram: dataset.instagram || '@ku_deta_gifu',
+    seats: dataset.seats || 'テーブル40席 / カウンター6席'
+  };
+
+  function bindText(attribute, value) {
+    document.querySelectorAll(`[data-bind="${attribute}"]`).forEach((el) => {
+      el.textContent = value;
+      if (el.tagName === 'A' && el.hasAttribute('href') && el.dataset.bind === 'phone') {
+        el.setAttribute('href', `tel:${value.replace(/[^0-9+]/g, '')}`);
+      }
+    });
+  }
+
+  bindText('address', info.address);
+  bindText('hours', info.hours);
+  bindText('phone', info.phone);
+  bindText('instagram', info.instagram);
+  bindText('seats', info.seats);
+
+  document.querySelectorAll('[data-reserve-link]').forEach((link) => {
+    link.setAttribute('href', info.reservationUrl);
+  });
+
+  const phoneLinks = document.querySelectorAll('[data-phone-link]');
+  phoneLinks.forEach((link) => {
+    link.setAttribute('href', `tel:${info.phone.replace(/[^0-9+]/g, '')}`);
+  });
+
+  const instagramLinks = document.querySelectorAll('[data-instagram-link]');
+  instagramLinks.forEach((link) => {
+    const handle = info.instagram.startsWith('@') ? info.instagram.slice(1) : info.instagram;
+    link.setAttribute('href', `https://www.instagram.com/${handle}/`);
+  });
+
+  const nav = document.querySelector('nav');
+  const navToggle = document.querySelector('.nav-toggle');
+  if (nav && navToggle) {
+    navToggle.addEventListener('click', () => {
+      const expanded = nav.getAttribute('aria-expanded') === 'true';
+      nav.setAttribute('aria-expanded', (!expanded).toString());
+      navToggle.setAttribute('aria-expanded', (!expanded).toString());
+    });
+
+    nav.querySelectorAll('a').forEach((link) => {
+      link.addEventListener('click', () => {
+        nav.setAttribute('aria-expanded', 'false');
+        navToggle.setAttribute('aria-expanded', 'false');
+      });
+    });
+  }
+
+  const header = document.querySelector('header');
+  if (header) {
+    const updateHeader = () => {
+      header.dataset.shrink = window.scrollY > 20 ? 'true' : 'false';
+    };
+    updateHeader();
+    window.addEventListener('scroll', updateHeader, { passive: true });
+  }
+
+  const tabList = document.querySelector('[role="tablist"]');
+  if (tabList) {
+    tabList.querySelectorAll('[role="tab"]').forEach((tab) => {
+      tab.addEventListener('click', () => {
+        const selected = tab.getAttribute('aria-controls');
+        tabList.querySelectorAll('[role="tab"]').forEach((btn) => {
+          const isActive = btn === tab;
+          btn.setAttribute('aria-selected', isActive.toString());
+          btn.setAttribute('tabindex', isActive ? '0' : '-1');
+        });
+
+        document.querySelectorAll('[role="tabpanel"]').forEach((panel) => {
+          panel.setAttribute('aria-hidden', (panel.id === selected ? 'false' : 'true'));
+        });
+      });
+    });
+  }
+
+  const reserveForm = document.getElementById('reserve-form');
+  if (reserveForm) {
+    const feedback = document.getElementById('reserve-feedback');
+    reserveForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const formData = new FormData(reserveForm);
+      const requiredFields = ['name', 'email', 'phone', 'date', 'time', 'guests'];
+      let valid = true;
+      reserveForm.querySelectorAll('.error-message').forEach((msg) => (msg.textContent = ''));
+
+      requiredFields.forEach((field) => {
+        const input = reserveForm.querySelector(`[name="${field}"]`);
+        if (!input) return;
+        if (!input.value.trim()) {
+          valid = false;
+          const holder = input.closest('label')?.querySelector('.error-message');
+          if (holder) {
+            holder.textContent = 'この項目は必須です。';
+          }
+        }
+      });
+
+      const email = formData.get('email');
+      if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.toString())) {
+        valid = false;
+        const holder = reserveForm.querySelector('[data-error="email"]');
+        if (holder) holder.textContent = 'メールアドレスの形式が正しくありません。';
+      }
+
+      const phone = formData.get('phone');
+      if (phone && !/^[0-9+\-]{9,15}$/.test(phone.toString())) {
+        valid = false;
+        const holder = reserveForm.querySelector('[data-error="phone"]');
+        if (holder) holder.textContent = '電話番号の形式をご確認ください。';
+      }
+
+      if (!valid) {
+        if (feedback) {
+          feedback.innerHTML = '<div class="alert-error" role="alert">入力内容をご確認ください。</div>';
+        }
+        return;
+      }
+
+      if (feedback) {
+        feedback.innerHTML = '<div class="alert-success" role="alert">仮予約を受け付けました。担当者より折り返しご連絡いたします。</div>';
+      }
+      reserveForm.reset();
+    });
+  }
+
+  const recruitForm = document.getElementById('recruit-form');
+  if (recruitForm) {
+    const feedback = document.getElementById('recruit-feedback');
+    recruitForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      let valid = true;
+      recruitForm.querySelectorAll('.error-message').forEach((msg) => (msg.textContent = ''));
+
+      ['applicant', 'contact', 'position', 'availability'].forEach((field) => {
+        const input = recruitForm.querySelector(`[name="${field}"]`);
+        if (!input) return;
+        if (!input.value.trim()) {
+          valid = false;
+          const holder = input.closest('label')?.querySelector('.error-message');
+          if (holder) holder.textContent = 'この項目は必須です。';
+        }
+      });
+
+      const resumeInput = recruitForm.querySelector('input[name="resume"]');
+      if (resumeInput) {
+        const file = resumeInput.files?.[0];
+        if (!file) {
+          valid = false;
+          const holder = recruitForm.querySelector('[data-error="resume"]');
+          if (holder) holder.textContent = 'PDFファイルを添付してください。';
+        } else if (file.type !== 'application/pdf') {
+          valid = false;
+          const holder = recruitForm.querySelector('[data-error="resume"]');
+          if (holder) holder.textContent = 'PDF形式のみアップロードできます。';
+        }
+      }
+
+      if (!valid) {
+        if (feedback) {
+          feedback.innerHTML = '<div class="alert-error" role="alert">入力内容をご確認ください。</div>';
+        }
+        return;
+      }
+
+      if (feedback) {
+        feedback.innerHTML = '<div class="alert-success" role="alert">応募を受け付けました。担当者より連絡いたします。</div>';
+      }
+      recruitForm.reset();
+    });
+  }
+
+  const ldRestaurant = {
+    '@context': 'https://schema.org',
+    '@type': 'Restaurant',
+    name: 'KU-DETA',
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: info.address,
+      addressLocality: '岐阜市',
+      addressRegion: '岐阜県',
+      postalCode: '500-0000',
+      addressCountry: 'JP'
+    },
+    telephone: info.phone,
+    servesCuisine: ['American', 'Pizza', 'Pasta', 'Cheese', 'Steak'],
+    priceRange: '\u00a5\u00a5',
+    openingHoursSpecification: [
+      {
+        '@type': 'OpeningHoursSpecification',
+        dayOfWeek: [
+          'Monday',
+          'Tuesday',
+          'Wednesday',
+          'Thursday',
+          'Friday',
+          'Saturday',
+          'Sunday'
+        ],
+        opens: '11:30',
+        closes: '23:00'
+      }
+    ],
+    acceptsReservations: true,
+    hasMenu: '#menu',
+    sameAs: [`https://www.instagram.com/${info.instagram.startsWith('@') ? info.instagram.slice(1) : info.instagram}/`]
+  };
+
+  const ldMenu = {
+    '@context': 'https://schema.org',
+    '@type': 'Menu',
+    name: 'KU-DETA メニュー',
+    hasMenuSection: [
+      {
+        '@type': 'MenuSection',
+        name: 'ランチ',
+        hasMenuItem: [
+          {
+            '@type': 'MenuItem',
+            name: '牛カツランチ',
+            description: '肉汁と衣のコントラストがクセになる看板ランチ。',
+            offers: { '@type': 'Offer', priceCurrency: 'JPY', price: '1600' }
+          },
+          {
+            '@type': 'MenuItem',
+            name: 'チーズフォンデュランチ',
+            description: '4種チーズをブレンドした濃厚フォンデュ。',
+            offers: { '@type': 'Offer', priceCurrency: 'JPY', price: '1800' }
+          }
+        ]
+      },
+      {
+        '@type': 'MenuSection',
+        name: 'ディナー',
+        hasMenuItem: [
+          {
+            '@type': 'MenuItem',
+            name: 'ワカモレ&チップス',
+            offers: { '@type': 'Offer', priceCurrency: 'JPY', price: '900' }
+          },
+          {
+            '@type': 'MenuItem',
+            name: 'シカゴピザ',
+            offers: { '@type': 'Offer', priceCurrency: 'JPY', price: '1800' }
+          }
+        ]
+      }
+    ]
+  };
+
+  const ldFaq = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: '予約は必要ですか？',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'お席を確実にご用意するため、オンラインまたはお電話での事前予約をおすすめしています。'
+        }
+      },
+      {
+        '@type': 'Question',
+        name: '記念日プレートは対応できますか？',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: '550円でメッセージ付きのデザートプレートをご用意します。ご予約時にメッセージ内容をお知らせください。'
+        }
+      },
+      {
+        '@type': 'Question',
+        name: '飲み放題プランはありますか？',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'アルコールは2,000円、ノンアルコールは1,500円でコースに追加いただけます。'
+        }
+      }
+    ]
+  };
+
+  [ldRestaurant, ldMenu, ldFaq].forEach((schema) => {
+    const script = document.createElement('script');
+    script.type = 'application/ld+json';
+    script.text = JSON.stringify(schema);
+    document.head.appendChild(script);
+  });
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,745 @@
+:root {
+  color-scheme: light dark;
+  --font-body: 'Inter', 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --color-bg: #fdfbf6;
+  --color-surface: rgba(255, 255, 255, 0.8);
+  --color-text: #1f1f1f;
+  --color-text-muted: #5a5a5a;
+  --color-primary: #b22234;
+  --color-primary-dark: #7b141e;
+  --color-secondary: #f6c56a;
+  --color-accent: #3d5a80;
+  --color-border: rgba(0, 0, 0, 0.08);
+  --shadow-soft: 0 20px 45px rgba(0, 0, 0, 0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #111317;
+    --color-surface: rgba(24, 26, 33, 0.88);
+    --color-text: #f5f5f5;
+    --color-text-muted: #c7c7c7;
+    --color-border: rgba(255, 255, 255, 0.08);
+    --shadow-soft: 0 20px 45px rgba(0, 0, 0, 0.4);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  font-size: 16px;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+main {
+  display: block;
+}
+
+button {
+  font-family: inherit;
+  cursor: pointer;
+}
+
+button:focus,
+input:focus,
+textarea:focus,
+select:focus {
+  outline: 3px solid var(--color-secondary);
+  outline-offset: 2px;
+}
+
+.container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+.section {
+  padding: clamp(3.5rem, 5vw, 6rem) 0;
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: clamp(2rem, 5vw, 3.5rem);
+}
+
+.section-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  letter-spacing: 0.08em;
+  margin: 0 0 1rem;
+}
+
+.section-subtitle {
+  max-width: 650px;
+  margin: 0 auto;
+  color: var(--color-text-muted);
+  font-size: 1rem;
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 999;
+  background: linear-gradient(135deg, rgba(17, 19, 23, 0.92), rgba(30, 11, 8, 0.92));
+  color: #fff;
+  backdrop-filter: blur(10px);
+  transition: padding 0.3s ease, box-shadow 0.3s ease;
+}
+
+header[data-shrink="true"] {
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.18);
+  padding: 0.35rem 0;
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0.75rem 4vw;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.nav-toggle {
+  display: inline-flex;
+  width: 44px;
+  height: 44px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 50%;
+  background: transparent;
+  color: #fff;
+}
+
+nav {
+  position: fixed;
+  inset: 0 0 0 auto;
+  width: min(280px, 75vw);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  background: rgba(10, 10, 10, 0.95);
+  padding: 6rem 2rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+nav[aria-expanded="true"] {
+  transform: translateX(0);
+}
+
+nav a {
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+@media (min-width: 960px) {
+  nav {
+    position: static;
+    inset: unset;
+    width: auto;
+    transform: none;
+    background: transparent;
+    flex-direction: row;
+    align-items: center;
+    padding: 0;
+    gap: 1.5rem;
+  }
+
+  .nav-toggle {
+    display: none;
+  }
+}
+
+.reserve-button {
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--color-secondary), #ffcf33);
+  color: #1a1107;
+  padding: 0.75rem 1.5rem;
+  font-weight: 700;
+  border: none;
+  box-shadow: 0 12px 24px rgba(255, 197, 106, 0.35);
+}
+
+.reserve-button:hover,
+.reserve-button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(255, 197, 106, 0.45);
+}
+
+.hero {
+  position: relative;
+  min-height: clamp(520px, 60vh, 720px);
+  display: grid;
+  align-items: center;
+  background: radial-gradient(circle at top left, rgba(255, 214, 138, 0.3), transparent 60%),
+    url('https://images.unsplash.com/photo-1551183053-bf91a1d81141?auto=format&fit=crop&w=1600&q=80') center/cover no-repeat;
+  color: #fff;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(0, 0, 0, 0.6), rgba(8, 6, 4, 0.2));
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  padding: clamp(4rem, 6vw, 8rem) 4vw;
+  display: grid;
+  gap: 1.5rem;
+  max-width: 640px;
+}
+
+.hero h1 {
+  font-size: clamp(2.75rem, 6vw, 4.25rem);
+  margin: 0;
+  letter-spacing: 0.12em;
+}
+
+.hero p {
+  font-size: clamp(1.1rem, 2.5vw, 1.4rem);
+  color: rgba(255, 255, 255, 0.86);
+  margin: 0;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.hero-actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  font-weight: 600;
+}
+
+.hero-actions a.primary {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
+  border: none;
+}
+
+.hero-actions a.secondary {
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.badges {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.badge {
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(6px);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+}
+
+.card-grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+@media (min-width: 768px) {
+  .card-grid.two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .card-grid.three {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .card-grid.four {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: 22px;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  box-shadow: var(--shadow-soft);
+  border: 1px solid var(--color-border);
+}
+
+.card h3 {
+  margin-top: 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.08em;
+}
+
+.card p {
+  margin-bottom: 0.5rem;
+  color: var(--color-text-muted);
+}
+
+.highlight-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  background: rgba(178, 34, 52, 0.12);
+  color: var(--color-primary);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-bottom: 0.75rem;
+}
+
+.menu-tabs {
+  display: grid;
+  gap: 1rem;
+}
+
+.menu-tablist {
+  display: inline-flex;
+  background: rgba(0, 0, 0, 0.05);
+  padding: 0.35rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  align-self: center;
+}
+
+.menu-tablist button {
+  border: none;
+  background: transparent;
+  padding: 0.5rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.menu-tablist button[aria-selected="true"] {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
+  color: #fff;
+}
+
+.menu-panel {
+  display: none;
+}
+
+.menu-panel[aria-hidden="false"] {
+  display: grid;
+  gap: 1rem;
+}
+
+.menu-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem 1.5rem;
+  background: rgba(255, 255, 255, 0.65);
+  border-radius: 18px;
+  border: 1px solid rgba(178, 34, 52, 0.15);
+}
+
+@media (prefers-color-scheme: dark) {
+  .menu-item {
+    background: rgba(30, 30, 32, 0.85);
+  }
+}
+
+.menu-item .details {
+  flex: 1;
+}
+
+.menu-item strong {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 1.1rem;
+}
+
+.menu-item .price {
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.course-comparison {
+  overflow-x: auto;
+}
+
+.course-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 620px;
+}
+
+.course-table th,
+.course-table td {
+  border: 1px solid var(--color-border);
+  padding: 1rem;
+  text-align: left;
+}
+
+.course-table th {
+  background: rgba(178, 34, 52, 0.1);
+}
+
+.wine-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .wine-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.wine-card {
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.85), rgba(255, 214, 138, 0.8));
+  padding: 1.5rem;
+  border-radius: 18px;
+  border: 1px solid rgba(178, 34, 52, 0.12);
+}
+
+.gallery {
+  column-count: 2;
+  column-gap: 1rem;
+}
+
+.gallery img {
+  width: 100%;
+  margin-bottom: 1rem;
+  border-radius: 16px;
+  box-shadow: var(--shadow-soft);
+}
+
+@media (min-width: 960px) {
+  .gallery {
+    column-count: 3;
+  }
+}
+
+.testimonials {
+  display: grid;
+  gap: 1rem;
+}
+
+.testimonial {
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 16px;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(178, 34, 52, 0.1);
+  font-style: italic;
+}
+
+@media (prefers-color-scheme: dark) {
+  .testimonial {
+    background: rgba(30, 30, 30, 0.85);
+  }
+}
+
+.access-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .access-grid {
+    grid-template-columns: 1fr 1fr;
+    align-items: stretch;
+  }
+}
+
+.map-embed iframe {
+  width: 100%;
+  min-height: 360px;
+  border: none;
+  border-radius: 18px;
+  box-shadow: var(--shadow-soft);
+}
+
+.reserve-card {
+  background: linear-gradient(160deg, rgba(178, 34, 52, 0.92), rgba(255, 197, 106, 0.85));
+  color: #fff;
+  padding: clamp(2rem, 4vw, 3rem);
+  border-radius: 28px;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.reserve-card form {
+  display: grid;
+  gap: 1rem;
+}
+
+label span {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.1);
+  color: inherit;
+  font-size: 1rem;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.error-message {
+  color: #ffe6e6;
+  font-size: 0.85rem;
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.form-actions button {
+  background: #fff;
+  color: var(--color-primary);
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 700;
+}
+
+.notice {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.instagram-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .instagram-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.instagram-grid iframe,
+.instagram-grid blockquote {
+  border-radius: 16px;
+  overflow: hidden;
+  min-height: 380px;
+}
+
+footer {
+  background: #0f1116;
+  color: #fff;
+  padding: 3rem 4vw 2rem;
+}
+
+.footer-top {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 900px) {
+  .footer-top {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.footer-brand h2 {
+  margin: 0 0 0.5rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.footer-nav {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.footer-cta {
+  background: linear-gradient(135deg, rgba(178, 34, 52, 0.9), rgba(255, 214, 138, 0.85));
+  color: #1f1109;
+  padding: 1.5rem;
+  border-radius: 18px;
+  display: grid;
+  gap: 1rem;
+}
+
+.footer-bottom {
+  margin-top: 2rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  padding-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.social-links {
+  display: inline-flex;
+  gap: 0.75rem;
+}
+
+.badge-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.badge-grid .card {
+  text-align: center;
+}
+
+.city-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .city-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.city-card {
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.75), rgba(255, 214, 138, 0.8));
+  border-radius: 22px;
+  padding: 1.5rem;
+  border: 1px solid rgba(178, 34, 52, 0.12);
+}
+
+.city-card h3 {
+  margin-top: 0;
+  letter-spacing: 0.08em;
+}
+
+.tag {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.3);
+  margin-right: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+.visually-hidden {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
+}
+
+.alert-success {
+  color: #0f5132;
+  background: rgba(209, 231, 221, 0.95);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+}
+
+.alert-error {
+  color: #842029;
+  background: rgba(248, 215, 218, 0.95);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+}
+
+.faq-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.faq-item {
+  border-radius: 14px;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.faq-item h3 {
+  margin: 0 0 0.5rem;
+}
+
+blockquote {
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .hero-actions {
+    width: 100%;
+  }
+
+  .hero-actions a {
+    flex: 1 1 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- implement single-page KU-DETA site with hero, concept, menu tabs, course information, wine, space, gallery, access, reserve, Instagram, and recruit sections
- add responsive styling, navigation interactions, tab UI, and forms with basic validation plus structured data injection via JavaScript
- document configuration points and local preview instructions in README

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_b_68cb7c671f108325a2b2b14734c2e647